### PR TITLE
Add Express backend for forwarding chat messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VueChatAccessPage
 
-访问 ChatGPT 的简单代理项目，现在包含一个基于 Vue 3 + Vite 的前端界面。
+访问 ChatGPT 的简单代理项目，现在包含一个基于 Vue 3 + Vite 的前端界面以及可选的 Node.js 后端服务。
 
 ## 前端（frontend/）
 
@@ -24,6 +24,42 @@ npm run dev
 
 开发模式下会自动代理以 `/api` 开头的请求到 `http://localhost:3000`，方便与后端联调。
 
+## 后端（server/）
+
+### 主要功能
+
+* 暴露 `POST /api/message` 接口，接收前端通过 multipart/form-data 发送的文本与图片，并将其转发至目标 GPT 接口（默认 OpenAI Responses API）。
+* 基于内存存储的上传处理，仅在需要时将图片转换为 base64 后嵌入请求。
+* 提供基础的日志记录与错误处理能力，敏感配置通过环境变量注入。
+
+### 开发环境准备
+
+1. 确保已安装 [Node.js](https://nodejs.org/)（建议 18+）和 npm。
+2. 在 `server/` 目录下执行依赖安装：
+
+   ```bash
+   cd server
+   npm install
+   ```
+
+### 环境变量
+
+在 `server/` 目录下复制 `.env.example` 生成 `.env`，并根据实际情况填写：
+
+```env
+OPENAI_API_KEY=sk-xxx                 # 必填，OpenAI API Key
+OPENAI_MODEL=gpt-4.1-mini             # 可选，默认值见示例
+PORT=3000                             # 可选，服务监听端口
+```
+
+### 本地启动
+
+```bash
+npm run start
+```
+
+服务默认监听 `http://localhost:3000`，与前端代理配置保持一致。启动后即可通过前端或其他客户端向 `/api/message` 发送 multipart/form-data 请求进行测试。
+
 ### 构建生产包
 
 ```bash
@@ -45,6 +81,9 @@ npm run preview
 ├── frontend/             # Vue 3 + Vite 前端项目
 │   ├── src/App.vue       # 聊天主页 UI 与交互逻辑
 │   └── ...
+├── server/               # Express 后端服务
+│   ├── index.js          # 服务入口及路由
+│   └── package.json      # 依赖与脚本
 └── README.md             # 项目说明
 ```
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in the required values.
+OPENAI_API_KEY=sk-your-openai-api-key
+OPENAI_MODEL=gpt-4.1-mini
+PORT=3000

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,111 @@
+require('dotenv').config();
+
+const express = require('express');
+const multer = require('multer');
+const morgan = require('morgan');
+
+const PORT = process.env.PORT || 3000;
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4.1-mini';
+
+const app = express();
+
+app.use(morgan('combined'));
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: 10 * 1024 * 1024, // 10MB per file
+    files: 5,
+  },
+});
+
+app.post('/api/message', upload.array('images', 5), async (req, res, next) => {
+  try {
+    if (!req.is('multipart/form-data')) {
+      return res.status(400).json({ error: { message: 'Content-Type must be multipart/form-data.' } });
+    }
+
+    if (!OPENAI_API_KEY) {
+      return res.status(500).json({ error: { message: 'Server is missing OpenAI credentials.' } });
+    }
+
+    const message = typeof req.body.message === 'string' ? req.body.message.trim() : '';
+    const files = Array.isArray(req.files) ? req.files : [];
+
+    if (!message && files.length === 0) {
+      return res.status(400).json({ error: { message: 'Either message text or an image is required.' } });
+    }
+
+    const content = [];
+
+    if (message) {
+      content.push({ type: 'input_text', text: message });
+    }
+
+    files.forEach((file) => {
+      if (!file.mimetype.startsWith('image/')) {
+        throw Object.assign(new Error('Only image uploads are supported.'), { status: 400 });
+      }
+
+      const base64 = file.buffer.toString('base64');
+      content.push({
+        type: 'input_image',
+        image_url: `data:${file.mimetype};base64,${base64}`,
+      });
+    });
+
+    const body = {
+      model: OPENAI_MODEL,
+      input: [
+        {
+          role: 'user',
+          content,
+        },
+      ],
+    };
+
+    const response = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      console.error('OpenAI API error:', data);
+      return res.status(response.status).json({
+        error: {
+          message: data.error?.message || 'Failed to process request.',
+        },
+      });
+    }
+
+    res.json({
+      result: data,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+app.use((err, req, res, next) => {
+  console.error(err);
+  if (res.headersSent) {
+    return next(err);
+  }
+  const status = err.status || 500;
+  res.status(status).json({
+    error: {
+      message: err.message || 'Internal Server Error',
+    },
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "vue-chat-access-server",
+  "version": "1.0.0",
+  "description": "Backend service for forwarding chat messages to GPT APIs.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "morgan": "^1.10.0"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}


### PR DESCRIPTION
## Summary
- add a Node.js Express backend that proxies multipart messages to the OpenAI Responses API
- include environment variable template and npm metadata for the new service
- document backend setup, configuration, and usage details in the README

## Testing
- npm install *(fails: registry access returns HTTP 403 in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a9775bb08332972cd460b52b0d3f