### PR TITLE
Fix FormData field names for server compatibility

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -40,10 +40,10 @@ async function handleSubmit() {
   responsePayload.value = null;
 
   const formData = new FormData();
-  formData.append('text', message.value);
+  formData.append('message', message.value);
 
   if (imageFile.value) {
-    formData.append('image', imageFile.value);
+    formData.append('images', imageFile.value);
   }
 
   try {


### PR DESCRIPTION
## Summary
- update the chat form to send `message` and `images` fields that align with the backend expectations

## Testing
- curl -i -X POST -F "message=hello world" http://localhost:3000/api/message

------
https://chatgpt.com/codex/tasks/task_e_68d8157415c88332ab83e7d6aa49257b