### PR TITLE
Add OpenAI beta header for responses API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -157,6 +157,7 @@ app.post('/api/message', upload.array('images', 5), async (req, res, next) => {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${OPENAI_API_KEY}`,
+        'OpenAI-Beta': 'assistants=v1',
       },
       body: JSON.stringify(body),
     });


### PR DESCRIPTION
## Summary
- add the OpenAI beta header to the responses endpoint request so the backend can call gpt-4.1-mini

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d8dda71b64833296af29b5d399a60a