### PR TITLE
Refactor OpenAI integration into reusable services

### DIFF
--- a/server/openaiClient.js
+++ b/server/openaiClient.js
@@ -1,0 +1,7 @@
+const OpenAI = require('openai');
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+});
+
+module.exports = client;

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,8 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "multer": "^1.4.5-lts.1",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "openai": "^4.56.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.3"

--- a/server/services/imageGeneration.js
+++ b/server/services/imageGeneration.js
@@ -1,0 +1,53 @@
+const client = require('../openaiClient');
+const { normaliseOpenAIError, readResponseBody } = require('../utils/openaiHelpers');
+
+async function generateImage({ prompt, size = '1024x1024' }) {
+  try {
+    const response = await client.images.generate({
+      model: 'gpt-image-1',
+      prompt,
+      size,
+      n: 1,
+      response_format: 'b64_json',
+    });
+
+    const imageResult = Array.isArray(response.data) ? response.data[0] : null;
+
+    return {
+      result: response,
+      image: imageResult
+        ? {
+            b64_json: imageResult.b64_json,
+            mime_type: imageResult.mime_type || 'image/png',
+          }
+        : null,
+    };
+  } catch (error) {
+    let parsed = null;
+    let raw = '';
+
+    if (error.response) {
+      const body = await readResponseBody(error.response);
+      parsed = body.parsed;
+      raw = body.raw;
+      console.error('OpenAI API error:', parsed ?? raw);
+    } else {
+      raw = error?.message || '';
+      console.error('OpenAI API error:', error);
+    }
+
+    const message = normaliseOpenAIError(
+      parsed,
+      raw,
+      'OpenAI API returned an unreadable response while generating the image. Please try again later.'
+    );
+
+    const normalisedError = new Error(message);
+    normalisedError.status = error.status || error.response?.status || 502;
+    throw normalisedError;
+  }
+}
+
+module.exports = {
+  generateImage,
+};

--- a/server/services/textGeneration.js
+++ b/server/services/textGeneration.js
@@ -1,0 +1,72 @@
+const client = require('../openaiClient');
+const { normaliseOpenAIError, readResponseBody } = require('../utils/openaiHelpers');
+
+function buildContent(message, files) {
+  const content = [];
+
+  if (message) {
+    content.push({ type: 'input_text', text: message });
+  }
+
+  files.forEach((file) => {
+    if (!file.mimetype.startsWith('image/')) {
+      throw Object.assign(new Error('Only image uploads are supported.'), { status: 400 });
+    }
+
+    const base64 = file.buffer.toString('base64');
+    content.push({
+      type: 'input_image',
+      image_url: `data:${file.mimetype};base64,${base64}`,
+    });
+  });
+
+  return content;
+}
+
+async function generateText({ message, files = [], model }) {
+  const content = buildContent(message, files);
+
+  try {
+    const response = await client.responses.create({
+      model,
+      input: [
+        {
+          role: 'user',
+          content,
+        },
+      ],
+      extra_headers: {
+        'OpenAI-Beta': 'assistants=v1',
+      },
+    });
+
+    return { result: response };
+  } catch (error) {
+    let parsed = null;
+    let raw = '';
+
+    if (error.response) {
+      const body = await readResponseBody(error.response);
+      parsed = body.parsed;
+      raw = body.raw;
+      console.error('OpenAI API error:', parsed ?? raw);
+    } else {
+      raw = error?.message || '';
+      console.error('OpenAI API error:', error);
+    }
+
+    const messageText = normaliseOpenAIError(
+      parsed,
+      raw,
+      'OpenAI API returned an unreadable response while processing the request. Please try again later.'
+    );
+
+    const normalisedError = new Error(messageText);
+    normalisedError.status = error.status || error.response?.status || 502;
+    throw normalisedError;
+  }
+}
+
+module.exports = {
+  generateText,
+};

--- a/server/utils/openaiHelpers.js
+++ b/server/utils/openaiHelpers.js
@@ -1,0 +1,47 @@
+function normaliseOpenAIError(parsedBody, rawBody, fallbackMessage = 'Failed to process request.') {
+  if (parsedBody?.error?.message) {
+    return parsedBody.error.message;
+  }
+
+  if (typeof rawBody === 'string' && rawBody.trim()) {
+    const trimmed = rawBody.trim();
+
+    if (trimmed.startsWith('<')) {
+      return 'OpenAI API returned an unexpected HTML response. Please try again later.';
+    }
+
+    return trimmed.length > 500 ? `${trimmed.slice(0, 500)}…` : trimmed;
+  }
+
+  return fallbackMessage;
+}
+
+async function readResponseBody(response) {
+  if (!response || typeof response.text !== 'function') {
+    return { parsed: null, raw: '' };
+  }
+
+  let rawBody = '';
+
+  try {
+    rawBody = await response.text();
+  } catch (error) {
+    console.error('Failed to read OpenAI error response body:', error);
+    return { parsed: null, raw: '' };
+  }
+
+  if (!rawBody) {
+    return { parsed: null, raw: '' };
+  }
+
+  try {
+    return { parsed: JSON.parse(rawBody), raw: rawBody };
+  } catch (error) {
+    return { parsed: null, raw: rawBody };
+  }
+}
+
+module.exports = {
+  normaliseOpenAIError,
+  readResponseBody,
+};


### PR DESCRIPTION
## Summary
- add the OpenAI SDK dependency and wire up a singleton client
- extract image and text generation flows into dedicated service modules
- keep shared error-normalisation helpers while simplifying the Express route

## Testing
- npm install openai *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/openai)*

------
https://chatgpt.com/codex/tasks/task_e_68d920a453f08332a2466052bd439480