### PR TITLE
Handle malformed multipart payloads safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ npm run start
 
 服务默认监听 `http://localhost:3000`，与前端代理配置保持一致。启动后即可通过前端或其他客户端向 `/api/message` 发送 multipart/form-data 请求进行测试。
 
+### 回归验证：异常 multipart 请求
+
+为避免未来回归导致服务在遇到损坏的 multipart 负载时抛出未处理异常，可使用以下步骤进行手动验证：
+
+1. 确保服务已启动并监听 `http://localhost:3000`。
+2. 运行下面的命令向接口发送一个缺失必要字段的损坏 multipart 请求（故意省略 `message` 与 `mode` 字段，并提供不完整的 boundary）：
+
+   ```bash
+   curl -i -X POST http://localhost:3000/api/message \
+     -H "Content-Type: multipart/form-data; boundary=boundary-test" \
+     --data-binary $'--boundary-test\r\nContent-Disposition: form-data; name="foo"\r\n\r\nbar\r\n--boundary-test'
+   ```
+
+3. 期望响应状态码为 `400`，并返回 JSON `{ "error": { "message": "invalid or unparsable multipart payload" } }`，表明服务正确处理异常负载而不会崩溃。
+
 ### 构建生产包
 
 ```bash

--- a/server/index.js
+++ b/server/index.js
@@ -35,8 +35,18 @@ app.post('/api/message', upload.array('images', 5), async (req, res, next) => {
       return res.status(500).json({ error: { message: 'Server is missing OpenAI credentials.' } });
     }
 
-    const message = typeof req.body.message === 'string' ? req.body.message.trim() : '';
-    const mode = typeof req.body.mode === 'string' ? req.body.mode.trim() : 'text';
+    const body = req.body ?? {};
+    const hasMessageField = Object.prototype.hasOwnProperty.call(body, 'message');
+    const hasModeField = Object.prototype.hasOwnProperty.call(body, 'mode');
+
+    if (!hasMessageField && !hasModeField) {
+      return res
+        .status(400)
+        .json({ error: { message: 'invalid or unparsable multipart payload' } });
+    }
+
+    const message = typeof body?.message === 'string' ? body.message.trim() : '';
+    const mode = typeof body?.mode === 'string' ? body.mode.trim() : 'text';
     const files = Array.isArray(req.files) ? req.files : [];
 
     if (!message && files.length === 0) {


### PR DESCRIPTION
## Summary
- default the parsed multipart body to a safe object and guard against missing message/mode fields
- return a 400 "invalid or unparsable multipart payload" response before business logic instead of letting the handler throw
- document manual regression steps to exercise the malformed multipart scenario

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9337b5d3c83329fc81669d88782db