### PR TITLE
Add Google Gemini API key placeholder to server config

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,5 @@
 # Copy this file to .env and fill in the required values.
 OPENAI_API_KEY=sk-your-openai-api-key
 OPENAI_MODEL=gpt-4.1-mini
+GOOGLE_GEMINI_API_KEY=your-google-gemini-api-key
 PORT=3000

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ const morgan = require('morgan');
 const PORT = process.env.PORT || 3000;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4.1-mini';
+const GOOGLE_GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY;
 
 const { generateImage } = require('./services/imageGeneration');
 const { generateText } = require('./services/textGeneration');


### PR DESCRIPTION
## Summary
- add a Google Gemini API key placeholder to the server environment template
- expose the Google Gemini API key from the server configuration for future use

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee34b8f8d883329997c473e31a127b