### PR TITLE
Add news search mode and disable legacy generation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VueChatAccessPage
 
-访问 ChatGPT 的简单代理项目，现在包含一个基于 Vue 3 + Vite 的前端界面以及可选的 Node.js 后端服务。
+访问 ChatGPT 的简单代理项目，现在包含一个基于 Vue 3 + Vite 的前端界面以及可选的 Node.js 后端服务。最新版本的界面已经聚焦在“新闻查询”能力：输入关键词即可获取来自主流媒体的新闻摘要列表。
 
 ## 前端（frontend/）
 
@@ -28,7 +28,10 @@ npm run dev
 
 ### 主要功能
 
-* 暴露 `POST /api/message` 接口，接收前端通过 multipart/form-data 发送的文本与图片，并将其转发至目标 GPT 接口（默认 OpenAI Responses API）。
+* 暴露 `POST /api/message` 接口，基于 `mode` 字段动态调用不同的能力：
+  * `news`：查询 `newsapi.org`，并返回最多 6 条与关键词相关的新闻结果。
+  * `text`：转发到 OpenAI Responses API，进行富文本生成（当前前端已关闭该模式）。
+  * `image`：调用 OpenAI 的图片生成功能（当前前端已关闭该模式）。
 * 基于内存存储的上传处理，仅在需要时将图片转换为 base64 后嵌入请求。
 * 提供基础的日志记录与错误处理能力，敏感配置通过环境变量注入。
 * 限制单个文本字段大小不超过 64KB，以避免异常的大字段请求占用内存。
@@ -48,8 +51,9 @@ npm run dev
 在 `server/` 目录下复制 `.env.example` 生成 `.env`，并根据实际情况填写：
 
 ```env
-OPENAI_API_KEY=sk-xxx                 # 必填，OpenAI API Key
+OPENAI_API_KEY=sk-xxx                 # 可选，启用文本/图片生成功能所需的 OpenAI API Key
 OPENAI_MODEL=gpt-4.1-mini             # 可选，默认值见示例
+NEWS_API_KEY=news-api-key             # 必填，NewsAPI.org 的访问密钥
 PORT=3000                             # 可选，服务监听端口
 ```
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,5 +1,6 @@
 # Copy this file to deploy/.env and fill in the required values before running docker compose.
 OPENAI_API_KEY=sk-your-openai-key
 OPENAI_MODEL=gpt-4.1-mini
+NEWS_API_KEY=newsapi-key
 FRONTEND_PORT=8080
 SERVER_PORT=3000

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,7 +16,7 @@ deploy/
 ## 前置条件
 
 1. 已在服务器上安装 [Docker](https://docs.docker.com/engine/install/) 与 [Docker Compose V2](https://docs.docker.com/compose/install/)。
-2. 拥有可用的 OpenAI API Key，并确认该 Key 具备访问所需模型的权限。
+2. 拥有可用的 [NewsAPI](https://newsapi.org/) Key（用于新闻检索）以及 OpenAI API Key（若需启用文本或图片生成功能）。
 
 ## 快速开始
 
@@ -40,8 +40,9 @@ deploy/
 
    | 变量名 | 说明 | 默认值 |
    | --- | --- | --- |
-   | `OPENAI_API_KEY` | 必填，OpenAI 接口访问凭证 | - |
+   | `OPENAI_API_KEY` | 可选，OpenAI 接口访问凭证 | - |
    | `OPENAI_MODEL` | 可选，后端调用的模型名称 | `gpt-4.1-mini` |
+   | `NEWS_API_KEY` | 必填，NewsAPI.org 接口访问凭证 | - |
    | `FRONTEND_PORT` | 可选，映射到宿主机的前端访问端口 | `8080` |
    | `SERVER_PORT` | 可选，映射到宿主机的后端端口 | `3000` |
 

--- a/server/index.js
+++ b/server/index.js
@@ -8,9 +8,11 @@ const PORT = process.env.PORT || 3000;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4.1-mini';
 const GOOGLE_GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY;
+const NEWS_API_KEY = process.env.NEWS_API_KEY;
 
 const { generateImage } = require('./services/imageGeneration');
 const { generateText } = require('./services/textGeneration');
+const { searchNews } = require('./services/newsSearch');
 
 const app = express();
 
@@ -32,10 +34,6 @@ app.post('/api/message', upload.array('images', 5), async (req, res, next) => {
       return res.status(400).json({ error: { message: 'Content-Type must be multipart/form-data.' } });
     }
 
-    if (!OPENAI_API_KEY) {
-      return res.status(500).json({ error: { message: 'Server is missing OpenAI credentials.' } });
-    }
-
     const body = req.body ?? {};
     const hasMessageField = Object.prototype.hasOwnProperty.call(body, 'message');
     const hasModeField = Object.prototype.hasOwnProperty.call(body, 'mode');
@@ -52,6 +50,25 @@ app.post('/api/message', upload.array('images', 5), async (req, res, next) => {
 
     if (!message && files.length === 0) {
       return res.status(400).json({ error: { message: 'Either message text or an image is required.' } });
+    }
+
+    if (mode === 'news') {
+      try {
+        const newsResponse = await searchNews({
+          query: message,
+          apiKey: NEWS_API_KEY,
+          pageSize: 6,
+        });
+
+        return res.json(newsResponse);
+      } catch (error) {
+        const status = error.status || 502;
+        return res.status(status).json({ error: { message: error.message } });
+      }
+    }
+
+    if (!OPENAI_API_KEY) {
+      return res.status(500).json({ error: { message: 'Server is missing OpenAI credentials.' } });
     }
 
     if (mode === 'image') {

--- a/server/services/newsSearch.js
+++ b/server/services/newsSearch.js
@@ -1,0 +1,77 @@
+const { URLSearchParams } = require('node:url');
+
+const NEWS_API_ENDPOINT = 'https://newsapi.org/v2/everything';
+
+function normaliseArticle(article) {
+  const title = article?.title?.trim() || '未命名新闻';
+  const description = article?.description?.trim() || '';
+  const url = article?.url?.trim() || '';
+  const source = article?.source?.name?.trim() || '';
+  const publishedAt = article?.publishedAt || '';
+
+  return { title, description, url, source, publishedAt };
+}
+
+async function searchNews({ query, apiKey, pageSize = 5, language = 'zh', sortBy = 'publishedAt' }) {
+  if (!query || !query.trim()) {
+    const error = new Error('新闻检索需要提供查询关键词。');
+    error.status = 400;
+    throw error;
+  }
+
+  if (!apiKey) {
+    const error = new Error('服务器缺少新闻数据源的访问密钥。');
+    error.status = 500;
+    throw error;
+  }
+
+  if (typeof fetch !== 'function') {
+    const error = new Error('当前运行环境不支持 fetch API。');
+    error.status = 500;
+    throw error;
+  }
+
+  const params = new URLSearchParams({
+    q: query,
+    apiKey,
+    language,
+    sortBy,
+    pageSize: String(pageSize),
+  });
+
+  const requestUrl = `${NEWS_API_ENDPOINT}?${params.toString()}`;
+  const response = await fetch(requestUrl, {
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    let errorMessage = `新闻服务请求失败：${response.status}`;
+    try {
+      const payload = await response.json();
+      if (payload?.message) {
+        errorMessage = `新闻服务请求失败：${payload.message}`;
+      }
+    } catch (parseError) {
+      // ignore JSON parse error, retain status-based message
+    }
+
+    const error = new Error(errorMessage);
+    error.status = response.status;
+    throw error;
+  }
+
+  const payload = await response.json();
+  const articles = Array.isArray(payload?.articles) ? payload.articles.map(normaliseArticle) : [];
+  const totalResults = Number.isInteger(payload?.totalResults) ? payload.totalResults : articles.length;
+
+  return {
+    query,
+    totalResults,
+    articles,
+    source: 'newsapi.org',
+  };
+}
+
+module.exports = {
+  searchNews,
+};


### PR DESCRIPTION
## Summary
- add a dedicated news query mode to the Vue frontend and hide the legacy text/image actions
- connect the backend to NewsAPI through a new service and handle the `news` mode in the `/api/message` route
- document the required `NEWS_API_KEY` variable in the root README and deployment assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f382a5dfd48332bcbe65aff1933105