### PR TITLE
Switch news retrieval to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm run dev
 ### 主要功能
 
 * 暴露 `POST /api/message` 接口，基于 `mode` 字段动态调用不同的能力：
-  * `news`：查询 `newsapi.org`，并返回最多 6 条与关键词相关的新闻结果。
+  * `news`：通过 RapidAPI 调用 `real-time-news-data` 服务，并返回最多 6 条与关键词相关的新闻结果。
   * `text`：转发到 OpenAI Responses API，进行富文本生成（当前前端已关闭该模式）。
   * `image`：调用 OpenAI 的图片生成功能（当前前端已关闭该模式）。
 * 基于内存存储的上传处理，仅在需要时将图片转换为 base64 后嵌入请求。
@@ -53,7 +53,8 @@ npm run dev
 ```env
 OPENAI_API_KEY=sk-xxx                 # 可选，启用文本/图片生成功能所需的 OpenAI API Key
 OPENAI_MODEL=gpt-4.1-mini             # 可选，默认值见示例
-NEWS_API_KEY=news-api-key             # 必填，NewsAPI.org 的访问密钥
+RAPIDAPI_KEY=rapidapi-key             # 必填，RapidAPI Real-Time News Data 服务的访问密钥
+RAPIDAPI_HOST=real-time-news-data.p.rapidapi.com  # 可选，默认即可
 PORT=3000                             # 可选，服务监听端口
 ```
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,6 +1,7 @@
 # Copy this file to deploy/.env and fill in the required values before running docker compose.
 OPENAI_API_KEY=sk-your-openai-key
 OPENAI_MODEL=gpt-4.1-mini
-NEWS_API_KEY=newsapi-key
+RAPIDAPI_KEY=rapidapi-key
+RAPIDAPI_HOST=real-time-news-data.p.rapidapi.com
 FRONTEND_PORT=8080
 SERVER_PORT=3000

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -16,7 +16,7 @@ deploy/
 ## 前置条件
 
 1. 已在服务器上安装 [Docker](https://docs.docker.com/engine/install/) 与 [Docker Compose V2](https://docs.docker.com/compose/install/)。
-2. 拥有可用的 [NewsAPI](https://newsapi.org/) Key（用于新闻检索）以及 OpenAI API Key（若需启用文本或图片生成功能）。
+2. 拥有可用的 [RapidAPI Real-Time News Data](https://rapidapi.com/letscrape-6bRBa3QguO5/api/real-time-news-data) Key（用于新闻检索）以及 OpenAI API Key（若需启用文本或图片生成功能）。
 
 ## 快速开始
 
@@ -42,7 +42,8 @@ deploy/
    | --- | --- | --- |
    | `OPENAI_API_KEY` | 可选，OpenAI 接口访问凭证 | - |
    | `OPENAI_MODEL` | 可选，后端调用的模型名称 | `gpt-4.1-mini` |
-   | `NEWS_API_KEY` | 必填，NewsAPI.org 接口访问凭证 | - |
+   | `RAPIDAPI_KEY` | 必填，RapidAPI 访问凭证 | - |
+   | `RAPIDAPI_HOST` | 可选，RapidAPI Host Header，默认 `real-time-news-data.p.rapidapi.com` | `real-time-news-data.p.rapidapi.com` |
    | `FRONTEND_PORT` | 可选，映射到宿主机的前端访问端口 | `8080` |
    | `SERVER_PORT` | 可选，映射到宿主机的后端端口 | `3000` |
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     environment:
       OPENAI_API_KEY: "${OPENAI_API_KEY}"
       OPENAI_MODEL: "${OPENAI_MODEL:-gpt-4.1-mini}"
+      RAPIDAPI_KEY: "${RAPIDAPI_KEY}"
+      RAPIDAPI_HOST: "${RAPIDAPI_HOST:-real-time-news-data.p.rapidapi.com}"
       PORT: "3000"
     ports:
       - "${SERVER_PORT:-3000}:3000"

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,4 +2,6 @@
 OPENAI_API_KEY=sk-your-openai-api-key
 OPENAI_MODEL=gpt-4.1-mini
 GOOGLE_GEMINI_API_KEY=your-google-gemini-api-key
+RAPIDAPI_KEY=your-rapidapi-key
+RAPIDAPI_HOST=real-time-news-data.p.rapidapi.com
 PORT=3000

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,8 @@ const PORT = process.env.PORT || 3000;
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4.1-mini';
 const GOOGLE_GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY;
-const NEWS_API_KEY = process.env.NEWS_API_KEY;
+const RAPIDAPI_KEY = process.env.RAPIDAPI_KEY;
+const RAPIDAPI_HOST = process.env.RAPIDAPI_HOST || 'real-time-news-data.p.rapidapi.com';
 
 const { generateImage } = require('./services/imageGeneration');
 const { generateText } = require('./services/textGeneration');
@@ -56,7 +57,8 @@ app.post('/api/message', upload.array('images', 5), async (req, res, next) => {
       try {
         const newsResponse = await searchNews({
           query: message,
-          apiKey: NEWS_API_KEY,
+          apiKey: RAPIDAPI_KEY,
+          apiHost: RAPIDAPI_HOST,
           pageSize: 6,
         });
 


### PR DESCRIPTION
## Summary
- replace NewsAPI integration with RapidAPI Real-Time News Data in the backend news search service
- expose new RAPIDAPI_KEY and RAPIDAPI_HOST environment variables in server and deployment templates
- update project documentation and Docker Compose configuration to reflect the new RapidAPI requirements

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3895622e88332bd1599bd4fe3ec4b